### PR TITLE
Clearing the add new slide form

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -246,5 +246,8 @@
     	});
 
     });
+	$('#myModal').on('show.bs.modal', function(){
+                 $(this).find('form')[0].reset();
+        });
 </script>
 {% endblock %}


### PR DESCRIPTION
If the user enters informations when editing a presentation and then he cancels the edit and after that he wants to add a new presentation , the add new slide form will contain the informations about the presentation that its update was canceled. 
To fix the problem , I added a code which will clear the add form once it's shown to the user.
